### PR TITLE
fix(enricher): replace only the responses examples property

### DIFF
--- a/openapi-enricher.js
+++ b/openapi-enricher.js
@@ -58,7 +58,17 @@ async function run(oaFile, options) {
     Object.entries(oa.paths).forEach(([path, methods]) => {
         Object.entries(methods).forEach(([method, methodOptions]) => {
             if (examples.paths.hasOwnProperty(path)) {
-                oa.paths[path][method] = Object.assign({}, methodOptions, examples.paths[path][method])
+                for (const [statusCode, response] of Object.entries(methodOptions.responses)) {
+                    if (!response.hasOwnProperty('content')) {
+                        continue;
+                    }
+
+                    for (const contentType of Object.keys(response.content)) {
+                        if (examples['paths'][path][method]['responses'][statusCode]?.['content'][contentType]['examples']) {
+                            oa['paths'][path][method]['responses'][statusCode]['content'][contentType]['examples'] = examples['paths'][path][method]['responses'][statusCode]['content'][contentType]['examples']
+                        }
+                    }
+                }
             }
         })
     })


### PR DESCRIPTION
## Actual behavior

In the current behavior, the enricher replaces all the defined content of the response, stripping most of the properties that are not present in the `examples` files.

## New behavior

In this PR, I propose to replace only the `examples` property, if it exists, so that nothing is stripped away, and nothing needs to be duplicated between the original file and the `examples` file.